### PR TITLE
Added support for cloudwatch alarm on lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,27 @@ resource "aws_iam_role_policy_attachment" "terraform_lambda_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+# Alarms
+
+resource "aws_cloudwatch_metric_alarm" "lambda_alarm" {
+  count               = var.lambda_enable_alarms ? 1 : 0
+  alarm_name          = "${var.lambda_function_name}-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  datapoints_to_alarm = "1"
+  alarm_description   = "An error running the ${var.lambda_function_name} lambda function occurred"
+  alarm_actions       = var.lambda_alarm_actions
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+}
+
 # Secrets
 
 resource "aws_iam_policy" "secret_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,18 @@ variable "lambda_iam_role_name" {
   description = "Name of IAM role to associate to lambda function"
 }
 
+variable "lambda_alarm_actions" {
+  type        = list(string)
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+  default     = []
+}
+
+variable "lambda_enable_alarms" {
+  type        = bool
+  description = "Set to true to enable alarms on the lambda function"
+  default     = false
+}
+
 variable "resource_tags" {
   type        = map(string)
   description = "Tags to add to resources created by this module (where applicable)"


### PR DESCRIPTION
This adds a cloudwatch alarm that will trigger if the lambda function fails. It's not created by default