### PR TITLE
Bypass deprecation error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - uses: lablabs/setup-tflint@v1
+      # Need to enable unsecure commands due to https://github.com/lablabs/setup-tflint/issues/4
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       name: Setup TFLint
       with:
         tflint_version: v0.18.0


### PR DESCRIPTION
Github actions build fails because the setup-tflint step uses an unsecure command and they have no fix for it yet. Adding the suggested environment variable as a workaround.